### PR TITLE
[Don't Merge] I think I found a bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Qumulo Core image files
+*.qimg

--- a/commit
+++ b/commit
@@ -1,0 +1,7 @@
+added Qumulo Core image files to .gitignore
+standardized spelling of trademarks
+pedantic wording changes
+constant for support e-mail
+print Qumulo cluster name in message
+more explicit about what the --sharepass is
+print progress bar to stderr

--- a/qupgrade.py
+++ b/qupgrade.py
@@ -145,7 +145,9 @@ def download_from_trends(qs):
                                         name=qimg)
         except:
             e = sys.exc_info()[1]
-            log_print("File creation error: %s" % e)
+            log_print("File creation error while trying to upload %s: %s" % (qimg, e))
+            log_print("Warning: If the uploaded %s is incomplete or corrupt, you will need to delete it manually." % qimg)
+            log_print("(Via a mountpoint or via the API using something like `qq fs_delete`.")
 
         ####  Only download if a local version of file doesn't exist.
         if not os.path.exists(qimg) or os.path.getsize(qimg) != rel["size"]:
@@ -177,17 +179,17 @@ def download_file(qimg, qs):
         done_buckets.append((i+1) * perc)
     downloaded_bytes = 0
     bucket_num = 0
-    sys.stderr.flush()
+    sys.stdout.flush()
     with open(qimg, 'wb') as fw:
         for chunk in rsp.iter_content(chunk_size=1000000):
             if chunk: # filter out keep-alive new chunks
                 fw.write(chunk)
                 downloaded_bytes += 1000000
                 if downloaded_bytes > done_buckets[bucket_num]:
-                    sys.stderr.write("%s%%  " % (bucket_num * 5, ))
-                    sys.stderr.flush()
+                    sys.stdout.write("%s%%  " % (bucket_num * 5, ))
+                    sys.stdout.flush()
                     bucket_num += 1
-    sys.stderr.write("\n")
+    sys.stdout.write("\n")
     log_print("Completed download of qimg file: %s" % qimg)
 
 

--- a/qupgrade.py
+++ b/qupgrade.py
@@ -17,7 +17,7 @@ try:
     import requests
     from qumulo.rest_client import RestClient
 except:
-    print("Unable to import requests and qumulo api bindings")
+    print("Unable to import requests and Qumulo api bindings")
     print("Please run the following command:")
     print("pip install qumulo_api requests")
     sys.exit()
@@ -29,6 +29,7 @@ import json
 from collections import OrderedDict
 
 TRENDS_DOMAIN = "https://trends.qumulo.com"
+QUMULO_SUPPORT_EMAIL = "care@qumulo.com"
 
 
 class QSettings(object):
@@ -105,8 +106,8 @@ def download_from_trends(qs):
         if release["version"] == qs.to_version:
             release_exists = True
     if not release_exists:
-        log_print("Desired release %s does not exist." % qs.to_version)
-        print("Please correct the upgrade version")
+        log_print("Specified Qumulo Core version %s does not exist." % qs.to_version)
+        print("Please correct the upgrade version.")
         sys.exit()
 
     #### create directory for upgrade qimgs ####
@@ -138,7 +139,7 @@ def download_from_trends(qs):
             log_print("qimg file is already uploaded: %s" % qumulo_qimg)
             continue
 
-        log_print("Preparing to download release: %s" % rel["version"])
+        log_print("Preparing to download Qumulo Core: %s" % rel["version"])
         try:
             qs.rc.fs.create_file(dir_path='/' + qs.upgrade_path,
                                         name=qimg)
@@ -150,23 +151,23 @@ def download_from_trends(qs):
         if not os.path.exists(qimg) or os.path.getsize(qimg) != rel["size"]:
             download_file(qimg, qs)
 
-        log_print("Load qimg file onto Qumulo via API: %s" % qimg)
+        log_print("Load qimg file onto Qumulo cluster via API: %s" % qimg)
         with open(qimg, 'rb') as fr:
             qs.rc.fs.write_file(path = '/%s/%s' % (
                                             qs.upgrade_path,
                                             qimg), 
                                         data_file=fr)
-        log_print("Upgrade file ready on Qumulo: %s" % qimg)
-        log_print("Removing local qimg: %s" % qimg)
+        log_print("Upgrade file ready on Qumulo cluster: %s" % qimg)
+        log_print("Removing local qimg file: %s" % qimg)
         os.remove(qimg)
 
 
 def download_file(qimg, qs):
-    log_print("Starting download of qimg: %s" % qimg)
+    log_print("Starting download of qimg file: %s" % qimg)
     rsp = requests.get(TRENDS_DOMAIN + "/data/upgrade/version/%s?access_code=%s" % \
                     (qimg, qs.sharepass), allow_redirects=False)
     if rsp.status_code == 404:
-        print("Unable to download qimg. Please check the --sharepass value.")
+        print("Unable to download qimg file. Please check the --sharepass password.")
         sys.exit()
     rsp = requests.get(rsp.headers["Location"], stream=True)
     file_size = int(rsp.headers["content-length"])
@@ -176,18 +177,18 @@ def download_file(qimg, qs):
         done_buckets.append((i+1) * perc)
     downloaded_bytes = 0
     bucket_num = 0
-    sys.stdout.flush()
+    sys.stderr.flush()
     with open(qimg, 'wb') as fw:
         for chunk in rsp.iter_content(chunk_size=1000000):
             if chunk: # filter out keep-alive new chunks
                 fw.write(chunk)
                 downloaded_bytes += 1000000
                 if downloaded_bytes > done_buckets[bucket_num]:
-                    sys.stdout.write("%s%%  " % (bucket_num * 5, ))
-                    sys.stdout.flush()
+                    sys.stderr.write("%s%%  " % (bucket_num * 5, ))
+                    sys.stderr.flush()
                     bucket_num += 1
-    sys.stdout.write("\n")
-    log_print("Completed download of qimg: %s" % qimg)
+    sys.stderr.write("\n")
+    log_print("Completed download of qimg file: %s" % qimg)
 
 
 def upgrade_cluster():
@@ -197,9 +198,9 @@ def upgrade_cluster():
     parser.add_argument('--quser', required=True, help='Qumulo API user')
     parser.add_argument('--qpass', required=True, help='Qumulo API password')
     parser.add_argument('--qpath', default='upgrade', help='Root-based path to install/find the upgrade qimg file on the cluster')
-    parser.add_argument('--sharepass', help='Share password. Contact Qumulo for details')
-    parser.add_argument('--vers', required=True, help='The version to upgrade to.')
-    parser.add_argument('--download-only', default=False, help='Do not run upgrades, only download qimgs from box', action='store_true')
+    parser.add_argument('--sharepass', help='Fileserver download password. Contact %s for details' % QUMULO_SUPPORT_EMAIL)
+    parser.add_argument('--vers', required=True, help='The Qumulo Core version to upgrade to.')
+    parser.add_argument('--download-only', default=False, help='Do not perform upgrades. Only download qimg files from fileserver', action='store_true')
     args = parser.parse_args()
 
     if args.vers == "latest":
@@ -212,7 +213,7 @@ def upgrade_cluster():
         pass
     else:
         log_print("Exiting")
-        print("'%s' is not a valid Qumulo version" % args.vers)
+        print("'%s' is not a valid Qumulo Core version" % args.vers)
         sys.exit()
 
     qs.to_version     = version_short(args.vers)
@@ -224,16 +225,16 @@ def upgrade_cluster():
     qs.download_only  = args.download_only
 
     ####   Set up the Qumulo REST client
-    log_print("Logging into qumulo cluster to begin upgrade process")
+    log_print("Logging into Qumulo cluster %s to begin upgrade process" % qs.host)
     try:
         qs.rc = RestClient(qs.host, 8000)
         qs.rc.login(qs.user, qs.password)
         log_print("Login succesful")
     except:
-        log_print("Unable to connect to Qumulo cluster via api")
-        log_print("Qumulo cluster details: %s, login: %s" % (
+        log_print("Unable to connect to Qumulo cluster %s via api" % qs.host)
+        log_print("Credentials used: username=%s, password=%s" % (
                                                     qs.user, qs.password))
-        print("Please correct your Qumulo credientials and try again.")
+        print("Please correct your Qumulo credentials and try again.")
         sys.exit()
 
     revision_id = qs.rc.version.version()['revision_id']
@@ -242,18 +243,17 @@ def upgrade_cluster():
     if version_num(qs.current_version) >= version_num(qs.to_version):
         log_print("!! Error !! Unable to upgrade")
         err_msg = "Can't upgrade to %s as you're " + \
-                "already on or past that release."
-        print(err_msg % qs.to_version)
+                "already on or past that release (%s)."
+        print(err_msg % qs.to_version, qs.current_version)
         sys.exit()
-    log_print("Current Qumulo version: %s" % qs.current_version)
-    log_print("Upgrading Qumulo through: %s -> %s" % (qs.current_version,
-                                                     qs.to_version))
+    log_print("Current Qumulo Core version     : %s" % qs.current_version)
+    log_print("Upgrading to Qumulo Core version: %s" % qs.to_version)
 
     if qs.sharepass is not None:
         download_from_trends(qs)
     elif qs.download_only:
         print("Please specify the --sharepass argument and value.")
-        print("If you don't have the password, please contact Qumulo.")
+        print("If you don't have the fileserver download password, please contact %s" % QUMULO_SUPPORT_EMAIL)
         sys.exit()
 
 
@@ -276,7 +276,7 @@ def upgrade_cluster():
                 time.sleep(10)
             tries += 1
         if not connected:
-            log_print("Qumulo API exception: Unable to login to cluster")
+            log_print("Qumulo API exception: Unable to login to Qumulo cluster %s" % qs.host)
 
         qimg = 'qumulo_core_%s.qimg' % vers['version']
         log_print("Upgrading to: %s" % vers['version'])
@@ -297,7 +297,7 @@ def upgrade_cluster():
         resp = qs.rc.upgrade.status_get()
         if resp['error_state'] != 'UPGRADE_ERROR_NO_ERROR':
             log_print("!Fatal Error! " + resp['error_state'])
-            print("Please contact care@qumulo.com")
+            print("Please contact %s" % QUMULO_SUPPORT_EMAIL)
             sys.exit()
         log_print("Upgrading cluster with: %s" % qimg_path)
         log_print("Upgrade PREPARE: %s" % vers['version'])
@@ -306,7 +306,7 @@ def upgrade_cluster():
         except:
             exc = sys.exc_info()[1]
             log_print("!Fatal Error! Prepare exception: %s" % exc)
-            print("Please contact care@qumulo.com")
+            print("Please contact %s" % QUMULO_SUPPORT_EMAIL)
             sys.exit()
 
         resp = qs.rc.upgrade.status_get()
@@ -328,7 +328,7 @@ def upgrade_cluster():
         else:
             log_print("!Fatal Error! The upgrade state is currently " + \
                             "unknown. Unable to arm.")
-            print("Please contact care@qumulo.com")
+            print("Please contact %s" % QUMULO_SUPPORT_EMAIL)
             sys.exit()
 
         err_msg = "Qumulo cluster ARMed with %s. Reloading kernel via " + \
@@ -337,7 +337,7 @@ def upgrade_cluster():
         time.sleep(10)
         version_data = None
         while version_data == None:
-            log_print("... Loading Qumulo software: %s ..." % \
+            log_print("... Loading Qumulo Core %s ..." % \
                                                 vers['version'])
             try:
                 ####  10 second timeout for rest client while waiting.


### PR DESCRIPTION
I know my track record is not good, but bear with me.

When I ran the script from 2.8.2 to 2.9.4, it hit 2.9.0, skipped to 2.9.2, and stopped there. It did not download any releases after 2.9.2. Once it upgraded to 2.9.2, I ran the script again and it grabbed the remaining two.

I believe what's happening is that once the script goes into skipping mode (waiting for the skipto release), it never comes back out. It will download the skipto release itself, but not download any other releases.

Unfortunately I was not able to test whether clearing the skipping mode flag fixes the problem because my cluster had already finished upgrading.

I hope this is clear and that I'm not wrong.

-Falko