### PR TITLE
Added filtering and python3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,16 +73,19 @@ The `"QUMULO_CLUSTERS"` section allows for multiple Qumulo clusters to be tracke
 
 `sample-config.json` is currently only set up to save data to hourly csv files. If you want to send Qumulo data to other databases, here is the json configurations you can add to your `config.json`:
 
-Optional parameter for QUMULO_CLUSTERS: client_ip_regex
-
-Example:
 ```json
   "host": "product.example.com",
   "user": "admin",
   "password": ""
   "client_ip_regex": "10.0.0.*"
 ```
-client_ip_regex is a regex based filter for the clients accessing the Qumulo
+host (required): Hostname or IP of the Qumulo cluster API server
+
+user (required): Username of account with API access
+
+password (required): Password for API user
+
+client_ip_regex (optional): a regex based filter for the clients accessing the Qumulo
 cluster. This allows for cleaning up metrics for only those clients that you
 are interested in storing metrics.
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ The `"QUMULO_CLUSTERS"` section allows for multiple Qumulo clusters to be tracke
 
 `sample-config.json` is currently only set up to save data to hourly csv files. If you want to send Qumulo data to other databases, here is the json configurations you can add to your `config.json`:
 
+Optional parameter for QUMULO_CLUSTERS: client_ip_regex
+
+Example:
+```json
+  "host": "product.example.com",
+  "user": "admin",
+  "password": ""
+  "client_ip_regex": "10.0.0.*"
+```
+client_ip_regex is a regex based filter for the clients accessing the Qumulo
+cluster. This allows for cleaning up metrics for only those clients that you
+are interested in storing metrics.
+
 ```json
 "influx": {"host": "influxdb.example.com",
             "db": "qumulo",
@@ -92,7 +105,7 @@ The `"QUMULO_CLUSTERS"` section allows for multiple Qumulo clusters to be tracke
         "event": "qumulo_fs_activity"
 },
 ```
-For the vaarious databases, you will need to have your own DB server set up to pass the data. You will also potentially need to create a new database withing the DB server. For splunk, you will need to enable the /services/collector/event in splunk and generate a token for the configuration file.
+For the various databases, you will need to have your own DB server set up to pass the data. You will also potentially need to create a new database withing the DB server. For splunk, you will need to enable the /services/collector/event in splunk and generate a token for the configuration file.
 
 
 The configuration parameters are pretty self-explanatory and described below.


### PR DESCRIPTION
@mabott 
This adds a function for the IP filtering. This is a per cluster config and works with any regex you'd expect for IPs. 

```
{
    "QUMULO_CLUSTERS":[
        {
            "host": "qumulo.example.com",
            "user": "admin",
            "password": "password",
            "client_ip_regex": "10.10.72.1[3-4]|10.10.0.185"
        }
    ],
    "DBS":{
            "influx": {"host": "influxdb",
            "db": "qumulo",
            "measurement": "qumulo_fs_activity"
            }
    },
    "IOPS_THRESHOLD": 1,
    "THROUGHPUT_THRESHOLD": 10000,
    "DIRECTORY_DEPTH_LIMIT": 4,
    "DIRECTORIES_ONLY": true,
    "DEBUG": true
}
```
It is built into the initial connection function as to eliminate the need to resolve IPs or create data structures unnecessarily.