### PR TITLE
Fix QFS-38515: ignore the dot release field when checking for quarterly releases

### DIFF
--- a/qupgrade.py
+++ b/qupgrade.py
@@ -105,7 +105,7 @@ class qumulo_release_mgr:
         self.latest_quarterly_release = sorted_quarterly_releases[-1]
 
     def is_quarterly(self, vers):
-        vers_num = get_version_num(vers)
+        vers_num = get_version_num(vers, True)
         return ((vers_num / 100) % 100 == 0) and vers_num >= 2090000
 
     def get_next_q(self, vers):

--- a/qupgrade_test.py
+++ b/qupgrade_test.py
@@ -27,6 +27,13 @@ class QupgradeTest(unittest.TestCase):
         assert qr.get_next_q("2.9.0") == 2100000
         assert qr.get_next_q("2.12.4") == 2130000
 
+    def test_is_quarterly(self):
+        global qr
+        assert qr.is_quarterly("4.0.0.2") == True
+        assert qr.is_quarterly("4.3.0") == True
+        assert qr.is_quarterly("5.0.0.1") == True
+        assert qr.is_quarterly("5.0.1") == False
+
     def test_upgrade_regular(self):
         global qr
         qr.get_path("2.12.2", "2.13.2")


### PR DESCRIPTION
Without this fix, release 5.0.0.1 is flagged as not a valid quarterly
release and lead to QFS-38515.